### PR TITLE
do not download from links that do not say they lead to a PDF file

### DIFF
--- a/gesp/spiders/hb.py
+++ b/gesp/spiders/hb.py
@@ -47,6 +47,8 @@ class SpdrHB(scrapy.Spider):
     
     def parse(self, response):
         for td in response.xpath("//tr/td[@class='dotright'][1]"):
+            if not "(pdf" in td.xpath(".//following-sibling::td/a[1]/text()").get():
+                continue
             link = "https://" + response.url.split("/")[2] + td.xpath(".//following-sibling::td/a[1]/@href").get()
             yield {
                 "postprocess": self.postprocess,


### PR DESCRIPTION
For the HB decision databases, check whether the link text refers to a PDF.

Fixes https://github.com/niklaswais/gesp/issues/9