### PR TITLE
OVG SN: skip links without PDF and fix PDF links

### DIFF
--- a/gesp/spiders/sn.py
+++ b/gesp/spiders/sn.py
@@ -160,16 +160,20 @@ class SpdrSN(scrapy.Spider):
             except:
                 output("could not retrieve " + tmp_link, "err")
             else:
-                url = None
+                doc_pattern = "^(.*[/])?([^/]*[.]pdf)([^a-z].*)?$"
+                file = None
                 for link in tree.xpath("//a[@target='_blank']"):
-                    maybe_url = link.xpath("./@href")[0]
-                    if not re.match("^documents/[^/]*[.]pdf", maybe_url):
-                        continue
-                    url = maybe_url
-                    break
-                if not url:
+                    text = "".join(link.xpath("./text()"))
+                    ref = link.xpath("./@href")[0]
+                    if re.match(doc_pattern, ref):
+                        file = re.sub(doc_pattern, "\\2", ref)
+                        break
+                    if re.match(doc_pattern, text):
+                        file = re.sub(doc_pattern, "\\2", text)
+                        break
+                if not file:
                     continue
-                url = "".join(url.split("%3BVolltext+%28hier+klicken%29"))
+                url = "documents/" + file
                 yield {
                     "wait": self.wait,
                     "date": data[-11:-1],

--- a/gesp/spiders/sn.py
+++ b/gesp/spiders/sn.py
@@ -160,7 +160,7 @@ class SpdrSN(scrapy.Spider):
             except:
                 output("could not retrieve " + tmp_link, "err")
             else:
-                doc_pattern = "^(.*[/])?([^/]*[.]pdf)([^a-z].*)?$"
+                doc_pattern = "^(.*[/])?([^/]*[.](pdf|docx))([^a-z].*)?$"
                 file = None
                 for link in tree.xpath("//a[@target='_blank']"):
                     text = "".join(link.xpath("./text()"))

--- a/gesp/spiders/sn.py
+++ b/gesp/spiders/sn.py
@@ -162,12 +162,14 @@ class SpdrSN(scrapy.Spider):
             else:
                 url = None
                 for link in tree.xpath("//a[@target='_blank']"):
-                    if 0 == len(link.xpath("./text()")):
+                    maybe_url = link.xpath("./@href")[0]
+                    if not re.match("^documents/[^/]*[.]pdf", maybe_url):
                         continue
-                    url = link.xpath("./@href")[0]
+                    url = maybe_url
                     break
                 if not url:
                     continue
+                url = "".join(url.split("%3BVolltext+%28hier+klicken%29"))
                 yield {
                     "wait": self.wait,
                     "date": data[-11:-1],

--- a/gesp/spiders/sn.py
+++ b/gesp/spiders/sn.py
@@ -160,10 +160,18 @@ class SpdrSN(scrapy.Spider):
             except:
                 output("could not retrieve " + tmp_link, "err")
             else:
+                url = None
+                for link in tree.xpath("//a[@target='_blank']"):
+                    if 0 == len(link.xpath("./text()")):
+                        continue
+                    url = link.xpath("./@href")[0]
+                    break
+                if not url:
+                    continue
                 yield {
                     "wait": self.wait,
                     "date": data[-11:-1],
                     "az": data.split("(")[0].strip(),
                     "court": "ovg",
-                    "link": "https://www.justiz.sachsen.de/ovgentschweb/" + tree.xpath("//a[@target='_blank']/@href")[0]
+                    "link": "https://www.justiz.sachsen.de/ovgentschweb/" + url
                 }

--- a/gesp/src/create_file.py
+++ b/gesp/src/create_file.py
@@ -59,7 +59,11 @@ def save_as_pdf(item, spider_name, spider_path): # spider.name, spider.path
     elif "body" in item: # Sachsen (AG/LG/OLG)
         content = item["body"]
     if content and "court" in item and "date" in item and "az" in item:
-        filename = item["court"] + "_" + item["date"] + "_" + item["az"] + ".pdf"
+        basename = item["court"] + "_" + item["date"] + "_" + item["az"]
+        if item["link"].endswith(".docx"):
+            filename = basename + ".docx"
+        else:
+            filename = basename + ".pdf"
         filepath = os.path.join(spider_path, spider_name, filename)
         try:
             with open(filepath, "wb") as f:


### PR DESCRIPTION
For SN OVG intermediate pages, skip links where the `a` element does not enclose text.

Fixes https://github.com/niklaswais/gesp/issues/11