### PR TITLE
gesp/spiders/ni.py: fix exception handler

### DIFF
--- a/gesp/spiders/ni.py
+++ b/gesp/spiders/ni.py
@@ -86,7 +86,7 @@ class SpdrNI(scrapy.Spider):
                     if (self.wait == True): timelib.sleep(1.75)
                     try:
                         txt = requests.get(self.base_url + href, headers=self.headers).text
-                    except:
+                    except Exception as e:
                         output(f"could not retrieve {self.base_url + href}: {str(e)}", "err")
                     else:
                         try:


### PR DESCRIPTION
This fixes unfriendly crashes due to an uncaught exception when the NI spider fails on URL retrievals:
```
  File "/usr/lib/python3.11/site-packages/scrapy/spidermiddlewares/depth.py", line 59, in process_spider_output
    yield from super().process_spider_output(response, result, spider)
  File "/usr/lib/python3.11/site-packages/scrapy/spidermiddlewares/base.py", line 58, in process_spider_output
    for o in result:
  File "/usr/lib/python3.11/site-packages/scrapy/core/spidermw.py", line 167, in process_sync
    yield from iterable
  File "/opt/gesp/gesp/spiders/ni.py", line 90, in parse
    output(f"could not retrieve {self.base_url + href}: {str(e)}", "err")
                                                             ^
NameError: name 'e' is not defined
```